### PR TITLE
Fix merge order

### DIFF
--- a/src/EnvJson.php
+++ b/src/EnvJson.php
@@ -145,7 +145,7 @@ final class EnvJson
                 }
 
                 // Merge dist into env data, overwriting existing keys
-                $envData = array_merge($envData, $decodedDist);
+                $envData = array_merge($decodedDist, $envData);
             } catch (JsonException $e) {
                 throw new InvalidJsonContentException("Invalid JSON in env.dist file: {$envDistJsonFile} - " . $e->getMessage(), 0, $e);
             } catch (InvalidJsonFileException $e) { // @codeCoverageIgnore

--- a/src/EnvJson.php
+++ b/src/EnvJson.php
@@ -144,7 +144,7 @@ final class EnvJson
                     throw new InvalidEnvJsonFormatException("Invalid JSON format in env.dist file: {$envDistJsonFile}. Expected array.");
                 }
 
-                // Merge dist into env data, overwriting existing keys
+                // Merge env into dist data, overwriting existing keys
                 $envData = array_merge($decodedDist, $envData);
             } catch (JsonException $e) {
                 throw new InvalidJsonContentException("Invalid JSON in env.dist file: {$envDistJsonFile} - " . $e->getMessage(), 0, $e);

--- a/tests/EnvJsonTest.php
+++ b/tests/EnvJsonTest.php
@@ -274,15 +274,15 @@ class EnvJsonTest extends TestCase
 
         // Create env.json
         $envContent = json_encode([
-            'FOO' => 'env-value',
-            'BAR' => 'env-value-only',
+            'FOO' => 'env-value-override',
+            'BAZ' => 'env-value-new',
         ]);
         file_put_contents($envFile, $envContent);
 
         // Create env.dist.json (overwrites FOO, adds BAZ)
         $envDistContent = json_encode([
-            'FOO' => 'dist-value-override',
-            'BAZ' => 'dist-value-new',
+            'FOO' => 'dist-value',
+            'BAR' => 'dist-value-only',
         ]);
         file_put_contents($envDistFile, $envDistContent);
 
@@ -297,11 +297,11 @@ class EnvJsonTest extends TestCase
             $this->assertInstanceOf(stdClass::class, $loadedEnv);
             // Check merged values
             $this->assertObjectHasProperty('FOO', $loadedEnv);
-            $this->assertSame('dist-value-override', $loadedEnv->FOO, 'Value from env.dist.json should override env.json');
+            $this->assertSame('env-value-override', $loadedEnv->FOO, 'Value from env.json should override env.dist.json');
             $this->assertObjectHasProperty('BAR', $loadedEnv);
-            $this->assertSame('env-value-only', $loadedEnv->BAR, 'Value only in env.json should persist');
+            $this->assertSame('dist-value-only', $loadedEnv->BAR, 'Value only in env.dist.json should persist');
             $this->assertObjectHasProperty('BAZ', $loadedEnv);
-            $this->assertSame('dist-value-new', $loadedEnv->BAZ, 'Value only in env.dist.json should be added');
+            $this->assertSame('env-value-new', $loadedEnv->BAZ, 'Value only in env.json should be added');
         } finally {
             // Clean up
             if (file_exists($envFile)) {


### PR DESCRIPTION
- From the documentation, I could read that "values ​​written in env.dist.json can be overridden by env.json."
- However, in the implementation, the merge order seemed to be reversed. The same is true for the test code.

I will submit a pull request for a branch that contains the above fix.